### PR TITLE
create docker image and push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,7 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Release image
+      run:
+        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+        make release-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.4
+FROM alpine:3.12.7
 
 RUN apk --no-cache add ca-certificates
 COPY dist/mascaras_linux_amd64/mascaras /usr/local/bin/mascaras

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.12.4
+
+RUN apk --no-cache add ca-certificates
+COPY dist/mascaras_linux_amd64/mascaras /usr/local/bin/mascaras
+WORKDIR /
+ENTRYPOINT ["/usr/local/bin/mascaras"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+GIT_VER := $(shell git describe --tags)
+DATE := $(shell date +%Y-%m-%dT%H:%M:%S%z)
+export GO111MODULE := on
+
+.PHONY: image release-image
+
+image:
+	docker build \
+		--tag ghcr.io/kayac/mascaras:$(GIT_VER) \
+		.
+
+release-image: image
+	docker push ghcr.io/kayac/mascaras:$(GIT_VER)


### PR DESCRIPTION
## background

To easily install Mascarus, it would be nice to have a docker image.

Assumed to be specified as an image of ECS Task.

It's easier to get the config file via s3, so I think this looks good.